### PR TITLE
Stacking and CC memory fixes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       with:
         python-version: ${{env.python_version}}
     - name: pytest
-      run: PYTHONPATH=src pytest tests/. --cov
+      run: PYTHONPATH=src pytest tests/. integration_tests/. --cov
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
       env:

--- a/integration_tests/cc_stack_test.py
+++ b/integration_tests/cc_stack_test.py
@@ -1,0 +1,51 @@
+import os
+from datetime import datetime
+
+from datetimerange import DateTimeRange
+
+# %%
+from noisepy.seis import cross_correlate, stack  # noisepy core functions
+from noisepy.seis.channelcatalog import (
+    XMLStationChannelCatalog,  # Required stationXML handling object
+)
+from noisepy.seis.datatypes import (  # Main configuration object
+    ConfigParameters,
+    StackMethod,
+)
+from noisepy.seis.numpystore import NumpyCCStore, NumpyStackStore
+from noisepy.seis.scedc_s3store import (  # Object to query SCEDC data from on S3
+    SCEDCS3DataStore,
+    channel_filter,
+)
+
+S3_STORAGE_OPTIONS = {"s3": {"anon": True}}
+S3_DATA = "s3://scedc-pds/continuous_waveforms/"
+S3_STATION_XML = "s3://scedc-pds/FDSNstationXML/CI/"  # S3 storage of stationXML
+
+
+def test_cc_stack(tmp_path):
+    path = str(tmp_path)
+
+    cc_data_path = os.path.join(path, "CCF")
+    stack_data_path = os.path.join(path, "STACK")
+    # timeframe for analysis
+    start = datetime(2002, 1, 1)
+    end = datetime(2002, 1, 3)
+    timerange = DateTimeRange(start, end)
+
+    config = ConfigParameters()  # default config parameters which can be customized
+
+    stations = "RPV,SVDß".split(",")
+    catalog = XMLStationChannelCatalog(S3_STATION_XML, storage_options=S3_STORAGE_OPTIONS)  # Station catalog
+    raw_store = SCEDCS3DataStore(
+        S3_DATA, catalog, channel_filter(stations, "BH"), timerange, storage_options=S3_STORAGE_OPTIONS
+    )  # Store for reading raw data from S3 bucket
+    cc_store = NumpyCCStore(cc_data_path)  # Store for writing CC data
+
+    cross_correlate(raw_store, config, cc_store)
+
+    cc_store = NumpyCCStore(cc_data_path, mode="r")
+    stack_store = NumpyStackStore(stack_data_path)
+    config.stack_method = StackMethod.LINEAR
+
+    stack(cc_store, stack_store, config)

--- a/src/noisepy/seis/stack.py
+++ b/src/noisepy/seis/stack.py
@@ -196,7 +196,6 @@ def stack_pair(
 
     t_load = tlog.log("loading CCF data")
     stack_results: List[Stack] = []
-    return stack_results
 
     # continue when there is no data or for auto-correlation
     if iseg <= 1 and fauto == 1:

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -1,7 +1,10 @@
+from unittest.mock import Mock
+
 import pytest
 from datetimerange import DateTimeRange
 
-from noisepy.seis.stack import validate_pairs
+from noisepy.seis.datatypes import ConfigParameters, Station
+from noisepy.seis.stack import stack, validate_pairs
 
 
 def test_validate_pairs():
@@ -13,3 +16,25 @@ def test_validate_pairs():
     assert validate_pairs(3, pair, 0, ts, 9)
     with pytest.raises(Exception):
         validate_pairs(3, pair, 0, ts, 10)
+
+
+# since stacking using the ProcessPoolExecutor the stores need to be serializable
+class SerializableMock(Mock):
+    def __reduce__(self):
+        return (Mock, ())
+
+
+def test_stack_error():
+    config = ConfigParameters()
+    sta = Station("CI", "BAK")
+    cc_store = SerializableMock()
+    cc_store.get_timespans.return_value = [DateTimeRange("2021-01-01", "2021-01-02")]
+    cc_store.get_station_pairs.return_value = [(sta, sta)]
+    cc_store.read_correlations.return_value = []
+
+    stack_store = SerializableMock()
+    stack_store.get_station_pairs.return_value = []
+    stack_store.contains.return_value = False
+    with pytest.raises(RuntimeError) as e:
+        stack(cc_store, stack_store, config)
+        assert "CI.BAK" in str(e)

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import MagicMock
 
 import pytest
 from datetimerange import DateTimeRange
@@ -19,9 +19,9 @@ def test_validate_pairs():
 
 
 # since stacking using the ProcessPoolExecutor the stores need to be serializable
-class SerializableMock(Mock):
+class SerializableMock(MagicMock):
     def __reduce__(self):
-        return (Mock, ())
+        return (MagicMock, ())
 
 
 def test_stack_error():

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -43,7 +43,7 @@ def test_stack_error():
     stack_store.contains.return_value = False
     with pytest.raises(RuntimeError) as e:
         stack(cc_store, stack_store, config)
-        assert "CI.BAK" in str(e)
+    assert "CI.BAK" in str(e)
 
 
 def test_stack_pair():


### PR DESCRIPTION
- Sort timespans/node pairs to ensure work is properly distributed across nodes
- Better error/summary report for stacking
- Release memory more aggressively in CC