### PR TITLE
Run on windows

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -25,6 +25,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -25,7 +25,6 @@ concurrency:
 
 jobs:
   deploy:
-    if: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,17 @@ jobs:
       uses: codecov/codecov-action@v3
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  unit_tests_win:
+    runs-on: windows-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3.3.0
+    - name: Setup NoisePy
+      uses: ./.github/actions/setup
+      with:
+        python-version: ${{env.python_version}}
+    - name: pytest
+      run: PYTHONPATH=src pytest tests/. integration_tests/.
   s1_s2:
     strategy:
       fail-fast: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,7 @@ jobs:
         set PYTHONPATH=src
         pytest tests/. integration_tests/.
   s1_s2:
+    if: false
     strategy:
       fail-fast: true
       matrix:
@@ -82,6 +83,7 @@ jobs:
       run: |
         noisepy stack --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --stack_method ${{matrix.method}} --format ${{matrix.format}}
   s1_s2_mpi:
+    if: false
     strategy:
       fail-fast: true
       matrix:
@@ -115,6 +117,7 @@ jobs:
       run: |
         mpiexec -n 3 noisepy stack --mpi --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --stack_method ${{matrix.method}} --format numpy
   s3_dates:
+    if: false
     strategy:
       fail-fast: true
       matrix:
@@ -135,6 +138,7 @@ jobs:
         --stations "SBC,RIO" --start_date 2022-02-02 --end_date 2022-02-04 \
         --config configs/s3_anon.yaml
   s3_singlepath:
+    if: false
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,6 @@ jobs:
         set PYTHONPATH=src
         pytest tests/. integration_tests/.
   s1_s2:
-    if: false
     strategy:
       fail-fast: true
       matrix:
@@ -83,7 +82,6 @@ jobs:
       run: |
         noisepy stack --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --stack_method ${{matrix.method}} --format ${{matrix.format}}
   s1_s2_mpi:
-    if: false
     strategy:
       fail-fast: true
       matrix:
@@ -117,7 +115,6 @@ jobs:
       run: |
         mpiexec -n 3 noisepy stack --mpi --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --stack_method ${{matrix.method}} --format numpy
   s3_dates:
-    if: false
     strategy:
       fail-fast: true
       matrix:
@@ -138,7 +135,6 @@ jobs:
         --stations "SBC,RIO" --start_date 2022-02-02 --end_date 2022-02-04 \
         --config configs/s3_anon.yaml
   s3_singlepath:
-    if: false
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,9 @@ jobs:
       with:
         python-version: ${{env.python_version}}
     - name: pytest
-      run: PYTHONPATH=src pytest tests/. integration_tests/.
+      run: |
+        set PYTHONPATH=src
+        pytest tests/. integration_tests/.
   s1_s2:
     strategy:
       fail-fast: true

--- a/src/noisepy/seis/numpystore.py
+++ b/src/noisepy/seis/numpystore.py
@@ -36,7 +36,7 @@ class NumpyArrayStore(ArrayStore):
         self.fs = get_filesystem(root_dir, storage_options=storage_options)
         path = Path(root_dir)
         prefix = get_fs_sep(root_dir).join(path.parts[1:])
-        self.prefix_regex = re.compile(f".*{prefix}/")
+        self.prefix_regex = re.compile(f".*{re.escape(prefix)}/")
         logger.info(f"Numpy store created at {root_dir}")
         self.raw_paths = None
 

--- a/src/noisepy/seis/utils.py
+++ b/src/noisepy/seis/utils.py
@@ -23,7 +23,10 @@ def get_filesystem(path: str, storage_options: dict = {}) -> fsspec.AbstractFile
     url = urlparse(path)
     # The storage_options coming from the ConfigParameters is keyed by protocol
     storage_options = storage_options.get(url.scheme, storage_options)
-    return fsspec.filesystem(url.scheme, **storage_options)
+    if url.scheme == S3_SCHEME:
+        return fsspec.filesystem(url.scheme, **storage_options)
+    else:
+        return fsspec.filesystem("file", **storage_options)
 
 
 def fs_join(path1: str, path2: str) -> str:

--- a/tests/test_channel_filter_store.py
+++ b/tests/test_channel_filter_store.py
@@ -7,7 +7,7 @@ from noisepy.seis.channel_filter_store import LocationChannelFilterStore
 from noisepy.seis.scedc_s3store import SCEDCS3DataStore
 
 
-def test_locaiton_filtering():
+def test_location_filtering():
     # This folder has 4 channel .ms files, 2 of which are the same channel, different location
     path = os.path.join(os.path.dirname(__file__), "./data/s3scedc")
     store = SCEDCS3DataStore(path, MockCatalog())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import pytest
 from fsspec.implementations.local import LocalFileSystem
@@ -5,9 +7,10 @@ from s3fs import S3FileSystem
 
 from noisepy.seis.utils import fs_join, get_filesystem, remove_nan_rows, unstack
 
+SEP = os.path.sep
 paths = [
-    ("/dir/", "file.csv", "/dir/file.csv"),
-    ("../relative", "file.json", "../relative/file.json"),
+    (f"{SEP}dir{SEP}", "file.csv", SEP.join(["", "dir", "file.csv"])),
+    (f"..{SEP}relative", "file.json", SEP.join(["..", "relative", "file.json"])),
     ("s3://bucket/path", "file.xml", "s3://bucket/path/file.xml"),
 ]
 


### PR DESCRIPTION
- Fix to `utils.get_filesystem` for Windows
- Escape the prefix used in a regex since on windows it can contain backslashes, which `re` will interpret as escape sequences.
- Run unit tests on Windows

Previous code was only working on posix paths, because the url scheme for `"/some/path"` is `""`, which to fsspec means "file" (local). But with a windows path like `"c:\some\path"`, the url scheme becomes `"c"`, which fsspec doesn't understand. 