### PR TITLE
Stacking fixes/improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ The data processing in NoisePy consists of three steps:
 used to download data from an FDSN web service. Alternatively, data from an [S3 bucket](https://s3.console.aws.amazon.com/s3/buckets/scedc-pds) can be copied
 locally using the `aws` CLI, or streamed directly from S3.
 2. **Step 1 - Cross Correlation**: Computes cross correlaton for pairs of stations/channels. This can done with either the `cross_correlate()` function or the `noisepy cross_correlate` CLI command.
-3. **Step 2 - Stacking**: This steps takes the cross correlation computations across multiple timespans and stacks them for a given station/channel pair. This can done with either the `stack()` function or the `noisepy stack` CLI command.
+3. **Step 2 - Stacking**: This steps takes the cross correlation computations across multiple timespans and stacks them for a given station/channel pair. This can done with either the `stack_cross_correlations()` function or the `noisepy stack` CLI command.
 
 ### Data Formats
 

--- a/src/noisepy/seis/__init__.py
+++ b/src/noisepy/seis/__init__.py
@@ -7,7 +7,7 @@ import logging
 from ._version import __version__  # noqa: F401
 from .download import download  # noqa: F401
 from .correlate import cross_correlate  # noqa: F401
-from .stack import stack  # noqa: F401
+from .stack import stack_cross_correlations  # noqa: F401
 
 """
 NoisePy is a Python package designed for fast and easy computation of ambient noise cross-correlation functions.
@@ -19,8 +19,9 @@ The main functions exported by the package are:
                     https://docs.obspy.org/packages/autogen/obspy.clients.fdsn.client.Client.get_waveforms.html
 - cross_correlate:  This is the core function of NoisePy, which performs Fourier transform to all noise data first
                     and loads them into the memory before they are further cross-correlated
-- stack:            Used to assemble and/or stack all cross-correlation functions computed for the staion pairs in
-                    the cross_correlate step
+- stack_cross_correlations:
+                    Used to assemble and/or stack all cross-correlation functions computed for the staion
+                    pairs in the cross_correlate step
 - noise_module:     Collection of functions used in the cross_correlate and stacking steps
 - plotting_modules: Utility functions for plotting the data
 """

--- a/src/noisepy/seis/correlate.py
+++ b/src/noisepy/seis/correlate.py
@@ -134,6 +134,10 @@ def cc_timespan(
     station_pairs = list(create_pairs(pair_filter, all_channels, fft_params.acorr_only).keys())
     # Check for stations that are already done, do this in parallel
     logger.info(f"Checking for stations already done: {len(station_pairs)} pairs")
+
+    stations = set([station for pair in station_pairs for station in pair])
+    _ = list(executor.map(lambda s: cc_store.contains(s, s, ts), stations))
+    tlog.log(f"check for {len(stations)} stations already done (warm up cache)")
     station_pair_dones = list(executor.map(lambda p: cc_store.contains(p[0], p[1], ts), station_pairs))
 
     missing_pairs = [pair for pair, done in zip(station_pairs, station_pair_dones) if not done]

--- a/src/noisepy/seis/datatypes.py
+++ b/src/noisepy/seis/datatypes.py
@@ -181,7 +181,7 @@ class ConfigParameters(BaseModel):
     stationxml: bool = Field(
         default=False, description="station.XML file used to remove instrument response for SAC/miniseed data"
     )
-    rm_resp: str = Field(default="no", description="select 'no' to not remove response and use 'inv','spectrum',")
+    rm_resp: str = Field(default="inv", description="select 'no' to not remove response and use 'inv','spectrum',")
     rm_resp_out: str = Field(default="VEL", description="output location from response removal")
     respdir: Optional[str] = Field(default=None, description="response directory")
     # some control parameters

--- a/src/noisepy/seis/hierarchicalstores.py
+++ b/src/noisepy/seis/hierarchicalstores.py
@@ -6,10 +6,12 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
+from time import sleep
 from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, TypeVar
 
 import fsspec
 import numpy as np
+from botocore.exceptions import ClientError
 from datetimerange import DateTimeRange
 
 from .datatypes import AnnotatedData, Station
@@ -18,6 +20,9 @@ from .utils import TimeLogger, fs_join, get_filesystem, unstack
 
 META_ATTR = "metadata"
 VERSION_ATTR = "version"
+FIND_RETRIES = 5
+FIND_RETRY_SLEEP = 0.05  # (seconds)
+ERR_SLOWDOWN = "SlowDown"
 
 logger = logging.getLogger(__name__)
 
@@ -214,12 +219,32 @@ class HierarchicalStoreBase(Generic[T]):
     def _load_src(self, src: str):
         if self.dir_cache.is_src_loaded(src):
             return
-        paths = [self.helper.parse_path(p) for p in self.helper.get_fs().find(fs_join(self.helper.get_root_dir(), src))]
+        paths = self._find(src)
+
         grouped_paths = defaultdict(list)
         for rec_sta, timespan in [p for p in paths if p]:
             grouped_paths[rec_sta].append(timespan)
         for rec_sta, timespans in grouped_paths.items():
             self.dir_cache.add(src, rec_sta, sorted(timespans, key=lambda t: t.start_datetime.timestamp()))
+
+    def _find(self, src):
+        i = 0
+        while i < FIND_RETRIES:
+            try:
+                i += 1
+                paths = [
+                    self.helper.parse_path(p)
+                    for p in self.helper.get_fs().find(fs_join(self.helper.get_root_dir(), src))
+                ]
+                return paths
+            except ClientError as e:
+                # when using S3 we sometimes get a SlowDown client error so back off if that happens
+                if e.response.get("Error", {}).get("Code", None) != ERR_SLOWDOWN:
+                    logger.error(f"Got ClientError while listing {src}: {e}")
+                    raise
+                logger.warning(f"Got ClientError while listing {src}: {e}. Retry {i} of {FIND_RETRIES}")
+                sleep(FIND_RETRY_SLEEP * i)
+        raise RuntimeError(f"Could not get directory listing for {src} after {FIND_RETRIES} retries")
 
     def append(self, timespan: DateTimeRange, src: Station, rec: Station, data: List[T]):
         path = self._get_path(src, rec, timespan)

--- a/src/noisepy/seis/plotting_modules.py
+++ b/src/noisepy/seis/plotting_modules.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import random
 from concurrent.futures import ThreadPoolExecutor
 
 import matplotlib.pyplot as plt
@@ -637,7 +636,6 @@ def plot_all_moveout(
     freqmax,
     ccomp,
     dist_inc,
-    sample_pairs=1.0,
     disp_lag=None,
     savefig=False,
     sdir=None,
@@ -694,9 +692,6 @@ def plot_all_moveout(
     indx1 = int((maxlag - disp_lag) / dt)
     indx2 = indx1 + 2 * int(disp_lag / dt) + 1
 
-    if sample_pairs < 1.0:
-        sta_pairs = random.sample(sta_pairs, int(len(sta_pairs) * sample_pairs))
-        logger.info(f"Plotting {len(sta_pairs)} sampled pairs")
     # cc matrix
     nwin = len(sta_pairs)
     data = np.zeros(shape=(nwin, indx2 - indx1), dtype=np.float32)

--- a/tests/test_cross_correlation.py
+++ b/tests/test_cross_correlation.py
@@ -45,6 +45,7 @@ def test_safe_read_channels():
 def test_correlation():
     config = ConfigParameters()
     config.samp_freq = 1.0
+    config.rm_resp = "no"  # since we are using a mock catalog
     path = os.path.join(os.path.dirname(__file__), "./data/cc")
     raw_store = SCEDCS3DataStore(path, MockCatalog())
     ts = raw_store.get_timespans()

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import dateutil
 import pytest
 
 from noisepy.seis.datatypes import ChannelType, ConfigParameters, StackMethod, Station
@@ -51,3 +52,17 @@ def test_storage_options():
     # scheme is '' for local files
     c.storage_options[""]["foo"] = "bar"
     assert c.get_storage_options("/local/file") == {"foo": "bar"}
+
+
+def test_config_dates():
+    c = ConfigParameters()
+    # defaults should be valid
+    c = ConfigParameters.model_validate(dict(c), strict=True)
+    c.start_date = dateutil.parser.isoparse("2021-01-01")  # no timezone
+    with pytest.raises(Exception):
+        c = ConfigParameters.model_validate(dict(c), strict=True)
+    c.start_date = dateutil.parser.isoparse("2021-01-01T09:00:00+09:00")  # not utc
+    with pytest.raises(Exception):
+        c = ConfigParameters.model_validate(dict(c), strict=True)
+    c.start_date = dateutil.parser.isoparse("2021-01-01T09:00:00+00:00")  # utc
+    c = ConfigParameters.model_validate(dict(c), strict=True)

--- a/tests/test_hierarchicalstores.py
+++ b/tests/test_hierarchicalstores.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 import pytest
 from datetimerange import DateTimeRange
-from utils import range
+from utils import date_range
 
 from noisepy.seis.hierarchicalstores import PairDirectoryCache
 from noisepy.seis.numpystore import NumpyArrayStore
@@ -12,9 +12,9 @@ from noisepy.seis.zarrstore import ZarrStoreHelper
 def test_dircache():
     cache = PairDirectoryCache()
 
-    ts1 = range(4, 1, 2)
-    ts2 = range(4, 2, 3)
-    ts3 = range(2, 1, 2)
+    ts1 = date_range(4, 1, 2)
+    ts2 = date_range(4, 2, 3)
+    ts3 = date_range(2, 1, 2)
 
     assert not cache.contains("src", "rec", ts1)
     assert cache.get_pairs() == []
@@ -39,21 +39,23 @@ def test_dircache():
     assert cache.get_timespans("src", "rec") == [ts3, ts1, ts2]
     assert cache.get_timespans("src2", "rec2") == []
 
-    tsh1 = range(4, 1, 1, 0, 1)
+    tsh1 = date_range(4, 1, 1, 0, 1)
     assert not cache.contains("src", "rec", tsh1)
     cache.add("src", "rec", [tsh1])
     assert cache.contains("src", "rec", tsh1)
     check_1day()
     assert cache.get_timespans("src", "rec") == [ts3, ts1, ts2, tsh1]
 
-    with pytest.raises(ValueError):
-        cache.add("src", "rec", [ts1, tsh1])
+    # add timespans with different lentghs
+    cache.add("src", "rec", [ts1, tsh1])
+    check_1day()
+    assert cache.contains("src", "rec", tsh1)
 
 
 numpy_paths = [
     (
         "some/path/CI.BAK/CI.ARV/2021_07_01_00_00_00T2021_07_02_00_00_00.tar.gz",
-        ("CI.ARV", range(7, 1, 2)),
+        ("CI.ARV", date_range(7, 1, 2)),
     ),
     ("some/path/CI.BAK/CI.BAK_CI.ARV/2021_07_01_00_00_00.tar.gz", None),
     ("some/path/CI.BAK/CI.BAK_CI.ARV/2021_07_01_00_00_00.tar.gz", None),
@@ -72,7 +74,7 @@ def test_numpy_parse_path(path: str, expected: Tuple[str, DateTimeRange]):
 zarr_paths = [
     (
         "some/path/CI.BAK/CI.ARV/2021_07_01_00_00_00T2021_07_02_00_00_00/0.0.0",
-        ("CI.ARV", range(7, 1, 2)),
+        ("CI.ARV", date_range(7, 1, 2)),
     ),
     ("some/path/CI.BAK/CI.BAK_CI.ARV/2021_07_01_00_00_00/0.0.0", None),
     ("some/path/CI.BAK/CI.BAK/2021_07_01_00_00_00/.zgroup", None),

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -75,3 +75,6 @@ def test_stack_pair():
     cc_store.read.return_value = ccs
     stacks = stack_pair(sta, sta, [ts, ts], cc_store, config)
     assert len(stacks) == 6
+    ts2 = date_range(1, 20, 22)
+    stacks = stacks = stack_pair(sta, sta, [ts2], cc_store, config)
+    assert len(stacks) == 0

--- a/tests/test_stackstores.py
+++ b/tests/test_stackstores.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from utils import range
+from utils import date_range
 
 from noisepy.seis.asdfstore import ASDFStackStore
 from noisepy.seis.datatypes import Stack, Station
@@ -31,7 +31,7 @@ def numpystore(tmp_path: Path) -> NumpyStackStore:
 def _stackstore_test_helper(store: StackStore):
     src = Station("nw", "sta1")
     rec = Station("nw", "sta2")
-    ts = range(4, 1, 2)
+    ts = date_range(4, 1, 2)
 
     stack1 = Stack("EE", "Allstack_linear", {"key1": "value1"}, np.random.random(10))
     stack2 = Stack("NZ", "Allstack_robust", {"key2": "value2"}, np.random.random(7))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from datetimerange import DateTimeRange
 
 
-def range(month: int, start_day: int, end_day: int, start_hr: int = 0, end_hr: int = 0):
+def date_range(month: int, start_day: int, end_day: int, start_hr: int = 0, end_hr: int = 0):
     return DateTimeRange(
         datetime(2021, month, start_day, start_hr).replace(tzinfo=timezone.utc),
         datetime(2021, month, end_day, end_hr).replace(tzinfo=timezone.utc),

--- a/tutorials/get_started.ipynb
+++ b/tutorials/get_started.ipynb
@@ -58,7 +58,7 @@
    },
    "outputs": [],
    "source": [
-    "from noisepy.seis import download, cross_correlate, stack, plotting_modules, __version__\n",
+    "from noisepy.seis import download, cross_correlate, stack_cross_correlations, plotting_modules, __version__\n",
     "from noisepy.seis.asdfstore import ASDFRawDataStore, ASDFCCStore, ASDFStackStore\n",
     "from noisepy.seis.datatypes import ConfigParameters\n",
     "from dateutil.parser import isoparse\n",
@@ -315,7 +315,7 @@
     "# open a new cc store in read-only mode since we will be doing parallel access for stacking\n",
     "cc_store = ASDFCCStore(cc_data_path, mode=\"r\")\n",
     "stack_store = ASDFStackStore(stack_data_path)\n",
-    "stack(cc_store, stack_store, config)"
+    "stack_cross_correlations(cc_store, stack_store, config)"
    ]
   },
   {

--- a/tutorials/noisepy_pnwstore_tutorial.ipynb
+++ b/tutorials/noisepy_pnwstore_tutorial.ipynb
@@ -73,7 +73,7 @@
    },
    "outputs": [],
    "source": [
-    "from noisepy.seis import cross_correlate, stack, plotting_modules       # noisepy core functions\n",
+    "from noisepy.seis import cross_correlate, stack_cross_correlations, plotting_modules       # noisepy core functions\n",
     "from noisepy.seis.asdfstore import ASDFCCStore, ASDFStackStore                          # Object to store ASDF data within noisepy\n",
     "from noisepy.seis.scedc_s3store import channel_filter\n",
     "from noisepy.seis.pnwstore import PNWDataStore\n",
@@ -312,7 +312,7 @@
     "# open a new cc store in read-only mode since we will be doing parallel access for stacking\n",
     "cc_store = ASDFCCStore(cc_data_path, mode=\"r\")\n",
     "stack_store = ASDFStackStore(stack_data_path)\n",
-    "stack(cc_store, stack_store, config)"
+    "stack_cross_correlations(cc_store, stack_store, config)"
    ]
   },
   {

--- a/tutorials/noisepy_scedc_tutorial.ipynb
+++ b/tutorials/noisepy_scedc_tutorial.ipynb
@@ -72,7 +72,7 @@
         "from noisepy.seis.datatypes import ConfigParameters, StackMethod        # Main configuration object\n",
         "from noisepy.seis.channelcatalog import XMLStationChannelCatalog        # Required stationXML handling object\n",
         "import os\n",
-        "from datetime import datetime\n",
+        "from datetime import datetime, timezone\n",
         "from datetimerange import DateTimeRange\n",
         "\n",
         "\n",
@@ -108,8 +108,8 @@
         "# SCEDC S3 bucket common URL characters for that day.\n",
         "S3_DATA = \"s3://scedc-pds/continuous_waveforms/\"\n",
         "# timeframe for analysis\n",
-        "start = datetime(2002, 1, 1)\n",
-        "end = datetime(2002, 1, 3)\n",
+        "start = datetime(2002, 1, 1, tzinfo=timezone.utc)\n",
+        "end = datetime(2002, 1, 3, tzinfo=timezone.utc)\n",
         "timerange = DateTimeRange(start, end)\n",
         "print(timerange)"
       ]
@@ -174,7 +174,8 @@
       },
       "outputs": [],
       "source": [
-        "\n",
+        "config.start_date = start\n",
+        "config.end_date = end\n",
         "config.acorr_only = False # only perform auto-correlation or not\n",
         "config.xcorr_only = True # only perform cross-correlation or not\n",
         "\n",

--- a/tutorials/noisepy_scedc_tutorial.ipynb
+++ b/tutorials/noisepy_scedc_tutorial.ipynb
@@ -66,7 +66,7 @@
       "source": [
         "%load_ext autoreload\n",
         "%autoreload 2\n",
-        "from noisepy.seis import cross_correlate, stack, __version__       # noisepy core functions\n",
+        "from noisepy.seis import cross_correlate, stack_cross_correlations, __version__       # noisepy core functions\n",
         "from noisepy.seis.asdfstore import ASDFCCStore, ASDFStackStore          # Object to store ASDF data within noisepy\n",
         "from noisepy.seis.scedc_s3store import SCEDCS3DataStore, channel_filter # Object to query SCEDC data from on S3\n",
         "from noisepy.seis.datatypes import ConfigParameters, StackMethod        # Main configuration object\n",
@@ -413,7 +413,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "stack(cc_store, stack_store, config)"
+        "stack_cross_correlations(cc_store, stack_store, config)"
       ]
     },
     {

--- a/tutorials/plot_stacks.ipynb
+++ b/tutorials/plot_stacks.ipynb
@@ -35,30 +35,10 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "QKSeQpk7WKlW"
-      },
-      "outputs": [],
-      "source": [
-        "plot_all_moveout(stack_store, 'Allstack_linear', 0.1, 0.2, 'ZZ', 1, sample_pairs=0.05)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
       "metadata": {},
       "outputs": [],
       "source": [
-        "plot_all_moveout(stack_store, 'Allstack_linear', 0.1, 0.2, 'ZZ', 1, sample_pairs=0.25)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "plot_all_moveout(stack_store, 'Allstack_linear', 0.1, 0.2, 'ZZ', 1, sample_pairs=1.0)"
+        "plot_all_moveout(stack_store, 'Allstack_linear', 0.1, 0.2, 'ZZ', 1)"
       ]
     }
   ],

--- a/tutorials/plot_stacks.ipynb
+++ b/tutorials/plot_stacks.ipynb
@@ -12,92 +12,33 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": null,
       "metadata": {
         "id": "vceZgD83PnNc"
       },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2023-10-06 12:25:14,349 8336924160 INFO numpystore.__init__(): store creating at s3://scoped-noise/scedc_CI_stack_v2/, mode=a, storage_options={'s3': {'anon': False}}\n",
-            "2023-10-06 12:25:14,350 8336924160 INFO numpystore.__init__(): Numpy store created at s3://scoped-noise/scedc_CI_stack_v2/\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "The autoreload extension is already loaded. To reload it, use:\n",
-            "  %reload_ext autoreload\n",
-            "Using NoisePy version 0.9.77.dev12\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "%load_ext autoreload\n",
         "%autoreload 2\n",
         "from noisepy.seis import __version__       # noisepy core functions\n",
         "from noisepy.seis.plotting_modules import plot_all_moveout\n",
         "from noisepy.seis.numpystore import NumpyStackStore\n",
+        "from noisepy.seis.datatypes import Stack, Station\n",
         "print(f\"Using NoisePy version {__version__}\")\n",
         "\n",
         "\n",
         "stack_data_path = \"s3://scoped-noise/scedc_CI_stack_v2/\"\n",
-        "# stack_data_path = \"s3://carlosgjs-noisepy/test_new/STACK/\"\n",
         "S3_STORAGE_OPTIONS = {\"s3\": {\"anon\": False}}\n",
         "stack_store = NumpyStackStore(stack_data_path, storage_options=S3_STORAGE_OPTIONS)"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": null,
       "metadata": {
         "id": "QKSeQpk7WKlW"
       },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2023-10-06 12:25:17,998 8336924160 INFO plotting_modules.plot_all_moveout(): Plotting 2009 sampled pairs\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Allstack_linear Allstack_linear\n"
-          ]
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "d29f869fe4214dd7bac5f00f0eb2dcc5",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "  0%|          | 0/2009 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "2023-10-06 12:25:20,916 12042219520 WARNING plotting_modules.load(): No data available for CI.MTG_CI.RRC/Allstack_linear/ZZ\n",
-            "2023-10-06 12:25:54,116 12042219520 WARNING plotting_modules.load(): No data available for CI.ERR_CI.RRC/Allstack_linear/ZZ\n",
-            "2023-10-06 12:26:32,173 12042219520 WARNING plotting_modules.load(): No data available for CI.GSC_CI.RRC/Allstack_linear/ZZ\n",
-            "2023-10-06 12:26:57,393 12042219520 WARNING plotting_modules.load(): No data available for CI.RRC_CI.WLS2/Allstack_linear/ZZ\n",
-            "2023-10-06 12:27:20,680 12042219520 WARNING plotting_modules.load(): No data available for CI.DTP_CI.RRC/Allstack_linear/ZZ\n",
-            "2023-10-06 12:28:12,544 12042219520 WARNING plotting_modules.load(): No data available for CI.RRC_CI.STG/Allstack_linear/ZZ\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "plot_all_moveout(stack_store, 'Allstack_linear', 0.1, 0.2, 'ZZ', 1, sample_pairs=0.05)"
       ]
@@ -107,7 +48,18 @@
       "execution_count": null,
       "metadata": {},
       "outputs": [],
-      "source": []
+      "source": [
+        "plot_all_moveout(stack_store, 'Allstack_linear', 0.1, 0.2, 'ZZ', 1, sample_pairs=0.25)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "plot_all_moveout(stack_store, 'Allstack_linear', 0.1, 0.2, 'ZZ', 1, sample_pairs=1.0)"
+      ]
     }
   ],
   "metadata": {

--- a/tutorials/plot_stacks.ipynb
+++ b/tutorials/plot_stacks.ipynb
@@ -1,0 +1,142 @@
+{
+  "cells": [
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "PIA2IaqUOeOA"
+      },
+      "source": [
+        "# NoisePy Plotting Stacks"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "id": "vceZgD83PnNc"
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "2023-10-06 12:25:14,349 8336924160 INFO numpystore.__init__(): store creating at s3://scoped-noise/scedc_CI_stack_v2/, mode=a, storage_options={'s3': {'anon': False}}\n",
+            "2023-10-06 12:25:14,350 8336924160 INFO numpystore.__init__(): Numpy store created at s3://scoped-noise/scedc_CI_stack_v2/\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "The autoreload extension is already loaded. To reload it, use:\n",
+            "  %reload_ext autoreload\n",
+            "Using NoisePy version 0.9.77.dev12\n"
+          ]
+        }
+      ],
+      "source": [
+        "%load_ext autoreload\n",
+        "%autoreload 2\n",
+        "from noisepy.seis import __version__       # noisepy core functions\n",
+        "from noisepy.seis.plotting_modules import plot_all_moveout\n",
+        "from noisepy.seis.numpystore import NumpyStackStore\n",
+        "print(f\"Using NoisePy version {__version__}\")\n",
+        "\n",
+        "\n",
+        "stack_data_path = \"s3://scoped-noise/scedc_CI_stack_v2/\"\n",
+        "# stack_data_path = \"s3://carlosgjs-noisepy/test_new/STACK/\"\n",
+        "S3_STORAGE_OPTIONS = {\"s3\": {\"anon\": False}}\n",
+        "stack_store = NumpyStackStore(stack_data_path, storage_options=S3_STORAGE_OPTIONS)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "id": "QKSeQpk7WKlW"
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "2023-10-06 12:25:17,998 8336924160 INFO plotting_modules.plot_all_moveout(): Plotting 2009 sampled pairs\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Allstack_linear Allstack_linear\n"
+          ]
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "d29f869fe4214dd7bac5f00f0eb2dcc5",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "  0%|          | 0/2009 [00:00<?, ?it/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "2023-10-06 12:25:20,916 12042219520 WARNING plotting_modules.load(): No data available for CI.MTG_CI.RRC/Allstack_linear/ZZ\n",
+            "2023-10-06 12:25:54,116 12042219520 WARNING plotting_modules.load(): No data available for CI.ERR_CI.RRC/Allstack_linear/ZZ\n",
+            "2023-10-06 12:26:32,173 12042219520 WARNING plotting_modules.load(): No data available for CI.GSC_CI.RRC/Allstack_linear/ZZ\n",
+            "2023-10-06 12:26:57,393 12042219520 WARNING plotting_modules.load(): No data available for CI.RRC_CI.WLS2/Allstack_linear/ZZ\n",
+            "2023-10-06 12:27:20,680 12042219520 WARNING plotting_modules.load(): No data available for CI.DTP_CI.RRC/Allstack_linear/ZZ\n",
+            "2023-10-06 12:28:12,544 12042219520 WARNING plotting_modules.load(): No data available for CI.RRC_CI.STG/Allstack_linear/ZZ\n"
+          ]
+        }
+      ],
+      "source": [
+        "plot_all_moveout(stack_store, 'Allstack_linear', 0.1, 0.2, 'ZZ', 1, sample_pairs=0.05)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": []
+    }
+  ],
+  "metadata": {
+    "@webio": {
+      "lastCommId": null,
+      "lastKernelId": null
+    },
+    "colab": {
+      "provenance": []
+    },
+    "gpuClass": "standard",
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.13"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
- Standardize and validate dates to be UTC
- Rename `stack()` function to `stack_cross_correlations()` to avoid name conflict with the `stack.py` module. @mdenolle another option is to rename the module. E.g to `stacking.py` and keep the function as `stack()`. WDYT?
- Parallelize data loading in `plot_all_moveout `. 
    - RFC: Support sub-sampling a portion of the station pairs for faster plotting (see comment inline)
- Add simple notebook for plotting existing stacked data
- Fix loading of config from S3 bucket
- Change default format to NUMPY

