### PR TITLE
Allow reading config from S3, refactor main

### DIFF
--- a/src/noisepy/seis/main.py
+++ b/src/noisepy/seis/main.py
@@ -43,7 +43,6 @@ class Command(Enum):
     DOWNLOAD = 1
     CROSS_CORRELATE = 2
     STACK = 3
-    ALL = 4
 
 
 class DataFormat(Enum):
@@ -276,10 +275,6 @@ def main(args: typing.Any):
         cmd_wrapper(run_cross_correlation, args.raw_data_path, args.ccf_path)
     if args.cmd == Command.STACK:
         cmd_wrapper(run_stack, args.ccf_path, args.stack_path)
-    if args.cmd == Command.ALL:
-        cmd_wrapper(run_download, None, args.raw_data_path)
-        cmd_wrapper(run_cross_correlation, args.raw_data_path, args.ccf_path)
-        cmd_wrapper(run_stack, args.ccf_path, args.stack_path)
 
 
 def add_path(parser, prefix: str):
@@ -344,7 +339,6 @@ def parse_args(arguments: Iterable[str]) -> argparse.Namespace:
     make_step_parser(subparsers, Command.DOWNLOAD, ["raw_data"])
     add_mpi(make_step_parser(subparsers, Command.CROSS_CORRELATE, ["raw_data", "ccf", "xml"]))
     add_mpi(make_step_parser(subparsers, Command.STACK, ["raw_data", "stack", "ccf"]))
-    add_mpi(make_step_parser(subparsers, Command.ALL, ["raw_data", "ccf", "stack", "xml"]))
 
     args = parser.parse_args(arguments)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,11 +1,18 @@
 from datetime import datetime, timezone
 from typing import List
+from unittest import mock
 
 import obspy
 import pytest
 
 from noisepy.seis.constants import NO_CCF_DATA_MSG, NO_DATA_MSG
-from noisepy.seis.main import Command, initialize_params, main, parse_args
+from noisepy.seis.main import (
+    Command,
+    _valid_config_file,
+    initialize_params,
+    main,
+    parse_args,
+)
 
 
 def test_parse_args():
@@ -68,3 +75,15 @@ def test_main_download(tmp_path):
                 "--channels=''",
             ],
         )
+
+
+def test_valid_config(tmp_path):
+    cfgfile = tmp_path.joinpath("config.yaml")
+    parser = mock.Mock()
+    assert not _valid_config_file(parser, str(cfgfile))
+    parser.error.assert_called_once()
+
+    parser = mock.Mock()
+    cfgfile.write_text("")  # creates the file
+    assert _valid_config_file(parser, str(cfgfile))
+    parser.error.assert_not_called()


### PR DESCRIPTION
Fixes issue #233 

Also refactor the running of stack/cc/download in main to removes reduntant/duplicated code. The code to load/save config, error handling and saving of the logs is now in one place.