### PR TITLE
Update PNWstore reader

### DIFF
--- a/src/noisepy/seis/pnwstore.py
+++ b/src/noisepy/seis/pnwstore.py
@@ -125,7 +125,6 @@ class PNWDataStore(RawDataStore):
                 f.seek(byteoffset)
                 buff = io.BytesIO(f.read(bytes))
                 stream += obspy.read(buff)
-        # taper each segment
         return ChannelData(stream)
 
     def get_inventory(self, timespan: DateTimeRange, station: Station) -> obspy.Inventory:

--- a/src/noisepy/seis/pnwstore.py
+++ b/src/noisepy/seis/pnwstore.py
@@ -126,8 +126,7 @@ class PNWDataStore(RawDataStore):
                 buff = io.BytesIO(f.read(bytes))
                 stream += obspy.read(buff)
         # taper each segment
-        stream = stream.taper(max_percentage=0.03)
-        return ChannelData(stream.merge(fill_value=0))
+        return ChannelData(stream)
 
     def get_inventory(self, timespan: DateTimeRange, station: Station) -> obspy.Inventory:
         return self.channel_catalog.get_inventory(timespan, station)


### PR DESCRIPTION
@kuanfufeng pointed out that the detrend and taper in the data client is not necessary and may create unwanted discontinuities in the merged stream. Detrending and/or taper will be implemented in the `preprocess_raw` function, so it's not the job of raw data store. I am removing these two lines of codes. 