### PR TITLE
chore: update PyPi publishing to use trusted publisher 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,15 +93,15 @@ jobs:
     needs: test-built-dist
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
     - uses: actions/download-artifact@v3
       with:
         name: releases
         path: dist
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.5
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      uses: pypa/gh-action-pypi-publish@release/v1
   push_to_registry:
     name: Push Docker image to Docker Hub
     needs: [publish-pypi, test-built-dist]


### PR DESCRIPTION
Fix #236 