### PR TITLE
feat: add https filesystem and support load yml from url

### DIFF
--- a/src/noisepy/seis/utils.py
+++ b/src/noisepy/seis/utils.py
@@ -47,10 +47,8 @@ def fs_join(path1: str, path2: str) -> str:
 def get_fs_sep(path1: str) -> str:
     """Helper for getting a path separator that can handle both S3 URLs and local file system paths"""
     url = urlparse(path1)
-    if url.scheme == S3_SCHEME:
-        return posixpath.sep
-    else:
-        return os.sep
+    fs = fsspec.filesystem(url.scheme)
+    return fs.sep
 
 
 def io_retry(func: Callable, *args, **kwargs) -> Any:

--- a/src/noisepy/seis/utils.py
+++ b/src/noisepy/seis/utils.py
@@ -16,6 +16,7 @@ from tqdm.contrib.logging import logging_redirect_tqdm
 from noisepy.seis.constants import AWS_EXECUTION_ENV
 
 S3_SCHEME = "s3"
+HTTPS_SCHEME = "https"
 FIND_RETRIES = 5
 FIND_RETRY_SLEEP = 0.1  # (100ms)
 utils_logger = logging.getLogger(__name__)
@@ -28,6 +29,8 @@ def get_filesystem(path: str, storage_options: dict = {}) -> fsspec.AbstractFile
     storage_options = storage_options.get(url.scheme, storage_options)
     if url.scheme == S3_SCHEME:
         return fsspec.filesystem(url.scheme, **storage_options)
+    elif url.scheme == HTTPS_SCHEME:
+        return fsspec.filesystem(url.scheme)
     else:
         return fsspec.filesystem("file", **storage_options)
 

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -11,7 +11,7 @@ def test_channeltype():
         ChannelType("toolong")
 
 
-@pytest.mark.parametrize("ch,orien", [("bhe", "e"), ("bhe_00", "e")])
+@pytest.mark.parametrize("ch,orien", [("bhe", "e"), ("bhe_00", "e"), ("BHU", "Z")])
 def test_orientation(ch, orien):
     ch = ChannelType(ch)
     assert ch.get_orientation() == orien

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,9 +3,10 @@ import os
 import numpy as np
 import pytest
 from fsspec.implementations.local import LocalFileSystem
+from fsspec.implementations.http import HTTPFileSystem
 from s3fs import S3FileSystem
 
-from noisepy.seis.utils import fs_join, get_filesystem, remove_nan_rows, unstack
+from noisepy.seis.utils import fs_join, get_filesystem, remove_nan_rows, unstack, get_fs_sep
 
 SEP = os.path.sep
 paths = [
@@ -24,12 +25,18 @@ fs_types = [
     ("s3://bucket/path", S3FileSystem),
     ("/some/file", LocalFileSystem),
     ("s3/local/file", LocalFileSystem),
+    ("https://abc.com/file", HTTPFileSystem)
 ]
 
 
 @pytest.mark.parametrize("path, fs_type", fs_types)
 def test_get_filesystem(path, fs_type):
     assert isinstance(get_filesystem(path), fs_type)
+
+
+@pytest.mark.parametrize("path, fs_type", fs_types)
+def test_fs_sep(path, fs_type):
+    assert get_fs_sep(path) == get_filesystem(path).sep
 
 
 def test_unstack():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,11 +2,17 @@ import os
 
 import numpy as np
 import pytest
-from fsspec.implementations.local import LocalFileSystem
 from fsspec.implementations.http import HTTPFileSystem
+from fsspec.implementations.local import LocalFileSystem
 from s3fs import S3FileSystem
 
-from noisepy.seis.utils import fs_join, get_filesystem, remove_nan_rows, unstack, get_fs_sep
+from noisepy.seis.utils import (
+    fs_join,
+    get_filesystem,
+    get_fs_sep,
+    remove_nan_rows,
+    unstack,
+)
 
 SEP = os.path.sep
 paths = [
@@ -25,7 +31,7 @@ fs_types = [
     ("s3://bucket/path", S3FileSystem),
     ("/some/file", LocalFileSystem),
     ("s3/local/file", LocalFileSystem),
-    ("https://abc.com/file", HTTPFileSystem)
+    ("https://abc.com/file", HTTPFileSystem),
 ]
 
 


### PR DESCRIPTION
The iml file has been added [here](https://github.com/noisepy/NoisePy/blob/main/configs/default.yml). Moreover, the raw [HTTPS url](https://raw.githubusercontent.com/noisepy/NoisePy/main/configs/default.yml) can read by ConfigParameters.

This should work now.
```python
config = ConfigParameters.load_yaml("https://raw.githubusercontent.com/noisepy/NoisePy/main/configs/default.yml")
```

This should fix #295 