### PR TITLE
chore: update to new version dependency and use s3store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,7 @@ tutorials/scedc_data/
 tutorials/ncedc_data/
 tutorials/cli/tmpdata
 tutorials/pnw_data
+tutorials/composite_data
 
 # Jupyterbook
 _build/

--- a/integration_tests/cc_stack_test.py
+++ b/integration_tests/cc_stack_test.py
@@ -18,7 +18,7 @@ from noisepy.seis.io.datatypes import (  # Main configuration object
     StackMethod,
 )
 from noisepy.seis.io.numpystore import NumpyCCStore, NumpyStackStore
-from noisepy.seis.io.scedc_s3store import (  # Object to query SCEDC data from on S3
+from noisepy.seis.io.s3store import (  # Object to query SCEDC data from on S3
     SCEDCS3DataStore,
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "PyYAML==6.0",
     "pydantic-yaml==1.0",
     "psutil>=5.9.5,<6.0.0",
-    "noisepy-seis-io>=0.1.11",
+    "noisepy-seis-io>=0.1.12",
 ]
 
 

--- a/src/noisepy/seis/main.py
+++ b/src/noisepy/seis/main.py
@@ -19,7 +19,7 @@ from noisepy.seis.io.channel_filter_store import (
 from noisepy.seis.io.channelcatalog import CSVChannelCatalog, XMLStationChannelCatalog
 from noisepy.seis.io.datatypes import ConfigParameters
 from noisepy.seis.io.numpystore import NumpyCCStore, NumpyStackStore
-from noisepy.seis.io.scedc_s3store import SCEDCS3DataStore
+from noisepy.seis.io.s3store import SCEDCS3DataStore
 from noisepy.seis.io.utils import fs_join, get_filesystem, io_retry
 from noisepy.seis.io.zarrstore import ZarrCCStore, ZarrStackStore
 

--- a/tests/test_cross_correlation.py
+++ b/tests/test_cross_correlation.py
@@ -19,7 +19,7 @@ from noisepy.seis.io.datatypes import (
     RmResp,
     Station,
 )
-from noisepy.seis.io.scedc_s3store import SCEDCS3DataStore
+from noisepy.seis.io.s3store import SCEDCS3DataStore
 
 
 def test_read_channels():

--- a/tutorials/_toc.yml
+++ b/tutorials/_toc.yml
@@ -8,6 +8,7 @@ chapters:
 - file: noisepy_datastore.ipynb
 - file: noisepy_scedc_tutorial.ipynb
 - file: noisepy_ncedc_tutorial.ipynb
+- file: noisepy_compositestore_tutorial.ipynb
 - file: CLI.md
 - file: cloud/checklist.md
 - file: cloud/aws-ec2.md

--- a/tutorials/noisepy_compositestore_tutorial.ipynb
+++ b/tutorials/noisepy_compositestore_tutorial.ipynb
@@ -1,0 +1,501 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "PIA2IaqUOeOA"
+   },
+   "source": [
+    "# NoisePy Composite DatastoreTutorial\n",
+    "\n",
+    "Noisepy is a python software package to process ambient seismic noise cross correlations. This tutorial aims to introduce the use of noisepy for a toy problem on a composite data store. It can be ran locally or on the cloud.\n",
+    "\n",
+    "The data is stored on AWS S3:\n",
+    "- SCEDC Data Set: https://scedc.caltech.edu/data/getstarted-pds.html\n",
+    "- NCEDC Data Set: https://ncedc.org/db/cloud/getstarted-pds.html"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we install the noisepy-seis package"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment and run this line if the environment doesn't have noisepy already installed:\n",
+    "# ! pip install noisepy-seis "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__Warning__: NoisePy uses ```obspy``` as a core Python module to manipulate seismic data. If you use Google Colab, restart the runtime now for proper installation of ```obspy``` on Colab."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "WtDb2_y3Oreg"
+   },
+   "source": [
+    "## Import necessary modules\n",
+    "\n",
+    "Then we import the basic modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "vceZgD83PnNc"
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "from noisepy.seis import cross_correlate, stack_cross_correlations, __version__    # noisepy core functions\n",
+    "from noisepy.seis.io.asdfstore import ASDFCCStore, ASDFStackStore                  # Object to store ASDF data within noisepy\n",
+    "from noisepy.seis.io.compositerawstore import CompositeRawStore\n",
+    "from noisepy.seis.io.s3store import SCEDCS3DataStore, NCEDCS3DataStore\n",
+    "from noisepy.seis.io.channel_filter_store import channel_filter\n",
+    "from noisepy.seis.io.datatypes import CCMethod, ConfigParameters, FreqNorm, RmResp, StackMethod, TimeNorm        # Main configuration object\n",
+    "from noisepy.seis.io.channelcatalog import XMLStationChannelCatalog                # Required stationXML handling object\n",
+    "import os\n",
+    "import shutil\n",
+    "from datetime import datetime, timezone\n",
+    "from datetimerange import DateTimeRange\n",
+    "\n",
+    "\n",
+    "from noisepy.seis.io.plotting_modules import plot_all_moveout\n",
+    "\n",
+    "print(f\"Using NoisePy version {__version__}\")\n",
+    "\n",
+    "path = \"./composite_data\" \n",
+    "\n",
+    "os.makedirs(path, exist_ok=True)\n",
+    "cc_data_path = os.path.join(path, \"CCF\")\n",
+    "stack_data_path = os.path.join(path, \"STACK\")\n",
+    "S3_STORAGE_OPTIONS = {\"s3\": {\"anon\": True}}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pntYzIYGNTn8"
+   },
+   "source": [
+    "We will work with a single day worth of data on SCEDC and NCEDC. The continuous data is organized with a single day and channel per miniseed. For this example, you can choose any year since 2002. We will just cross correlate a single day."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "yojR0Z3ALm6K"
+   },
+   "outputs": [],
+   "source": [
+    "# SCEDC S3 bucket common URL characters for that day.\n",
+    "SCEDC_DATA = \"s3://scedc-pds/continuous_waveforms/\"\n",
+    "NCEDC_DATA = \"s3://ncedc-pds/continuous_waveforms/NC/\"\n",
+    "\n",
+    "SCEDC_STATION_XML = \"s3://scedc-pds/FDSNstationXML/CI/\"  \n",
+    "NCEDC_STATION_XML = \"s3://ncedc-pds/FDSNstationXML/NC/\"\n",
+    "\n",
+    "# timeframe for analysis\n",
+    "start = datetime(2012, 1, 1, tzinfo=timezone.utc)\n",
+    "end = datetime(2012, 1, 3, tzinfo=timezone.utc)\n",
+    "timerange = DateTimeRange(start, end)\n",
+    "print(timerange)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ssaL5fa5IhI7"
+   },
+   "source": [
+    "## Ambient Noise Project Configuration\n",
+    "\n",
+    "We prepare the configuration of the workflow by declaring and storing parameters into the ``ConfigParameters()`` object and/or editing the ``config.yml`` file.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "dIjBD7riIfdJ"
+   },
+   "outputs": [],
+   "source": [
+    "# Initialize ambient noise workflow configuration\n",
+    "config = ConfigParameters() # default config parameters which can be customized\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Tsp7RfC8IwE-"
+   },
+   "source": [
+    "Customize the job parameters below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ByEiHRjmIAPB"
+   },
+   "outputs": [],
+   "source": [
+    "config.start_date = start\n",
+    "config.end_date = end\n",
+    "config.acorr_only = False # only perform auto-correlation or not\n",
+    "config.xcorr_only = True # only perform cross-correlation or not\n",
+    "\n",
+    "config.inc_hours = 24 # INC_HOURS is used in hours (integer) as the \n",
+    "        #chunk of time that the paralelliztion will work.\n",
+    "        # data will be loaded in memory, so reduce memory with smaller \n",
+    "        # inc_hours if there are over 400+ stations.\n",
+    "        # At regional scale for SCEDC, we can afford 20Hz data and inc_hour \n",
+    "        # being a day of data.\n",
+    "\n",
+    "# pre-processing parameters\n",
+    "config.samp_freq= 20  # (int) Sampling rate in Hz of desired processing (it can be different than the data sampling rate)\n",
+    "config.single_freq = False\n",
+    "config.cc_len= 3600  # (float) basic unit of data length for fft (sec)\n",
+    "config.step= 1800.0  # (float) overlapping between each cc_len (sec)\n",
+    "\n",
+    "config.ncomp = 3  # 1 or 3 component data (needed to decide whether do rotation)\n",
+    "\n",
+    "config.stationxml= False  # station.XML file used to remove instrument response for SAC/miniseed data\n",
+    "      # If True, the stationXML file is assumed to be provided.\n",
+    "config.rm_resp= RmResp.INV  # select 'no' to not remove response and use 'inv' if you use the stationXML,'spectrum',\n",
+    "\n",
+    "\n",
+    "############## NOISE PRE-PROCESSING ##################\n",
+    "config.freqmin,config.freqmax = 0.05,2.0  # broad band filtering of the data before cross correlation\n",
+    "config.max_over_std  = 10  # threshold to remove window of bad signals: set it to 10*9 if prefer not to remove them\n",
+    "\n",
+    "################### SPECTRAL NORMALIZATION ############\n",
+    "config.freq_norm= FreqNorm.RMA  # choose between \"rma\" for a soft whitening or \"no\" for no whitening. Pure whitening is not implemented correctly at this point.\n",
+    "config.smoothspect_N = 10  # moving window length to smooth spectrum amplitude (points)\n",
+    "    # here, choose smoothspect_N for the case of a strict whitening (e.g., phase_only)\n",
+    "\n",
+    "\n",
+    "#################### TEMPORAL NORMALIZATION ##########\n",
+    "config.time_norm = TimeNorm.ONE_BIT # 'no' for no normalization, or 'rma', 'one_bit' for normalization in time domain,\n",
+    "config.smooth_N= 10  # moving window length for time domain normalization if selected (points)\n",
+    "\n",
+    "\n",
+    "############ cross correlation ##############\n",
+    "\n",
+    "config.cc_method= CCMethod.XCORR # 'xcorr' for pure cross correlation OR 'deconv' for deconvolution;\n",
+    "    # FOR \"COHERENCY\" PLEASE set freq_norm to \"rma\", time_norm to \"no\" and cc_method to \"xcorr\"\n",
+    "\n",
+    "# OUTPUTS:\n",
+    "config.substack = True  # True = smaller stacks within the time chunk. False: it will stack over inc_hours\n",
+    "config.substack_len = config.cc_len  # how long to stack over (for monitoring purpose): need to be multiples of cc_len\n",
+    "    # if substack=True, substack_len=2*cc_len, then you pre-stack every 2 correlation windows.\n",
+    "    # for instance: substack=True, substack_len=cc_len means that you keep ALL of the correlations\n",
+    "    # if substack=False, the cross correlation will be stacked over the inc_hour window\n",
+    "\n",
+    "### For monitoring applications ####\n",
+    "## we recommend substacking ever 2-4 cross correlations and storing the substacks\n",
+    "# e.g. \n",
+    "# config.substack = True \n",
+    "# config.substack_len = 4* config.cc_len\n",
+    "\n",
+    "config.maxlag= 200  # lags of cross-correlation to save (sec)\n",
+    "\n",
+    "# the network list that are used here\n",
+    "config.net_list = ['CI', 'NC']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For this tutorial make sure the previous run is empty\n",
+    "#os.system(f\"rm -rf {cc_data_path}\")\n",
+    "if os.path.exists(cc_data_path):\n",
+    "    shutil.rmtree(cc_data_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Wwv1QCQhP_0Y"
+   },
+   "source": [
+    "## Step 1: Cross-correlation\n",
+    "\n",
+    "In this instance, we read directly the data from the scedc bucket into the cross correlation code. We are not attempting to recreate a data store. Therefore we go straight to step 1 of the cross correlations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We first declare the data and cross correlation stores"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "jq2DKIS9Rl2H"
+   },
+   "outputs": [],
+   "source": [
+    "scedc_stations = \"RPV,SVD,BBR\".split(\",\")  # SCEDC station\n",
+    "ncedc_stations = \"KCT,KRP,KHMB\".split(\",\") # NCEDC station\n",
+    "\n",
+    "scedc_catalog = XMLStationChannelCatalog(SCEDC_STATION_XML, \n",
+    "                                         storage_options=S3_STORAGE_OPTIONS)\n",
+    "ncedc_catalog = XMLStationChannelCatalog(NCEDC_STATION_XML, \"{network}.{name}.xml\", \n",
+    "                                         storage_options=S3_STORAGE_OPTIONS)\n",
+    "\n",
+    "\n",
+    "scedc_store = SCEDCS3DataStore(SCEDC_DATA, scedc_catalog,  channel_filter([\"CI\"], scedc_stations, [\"BHE\", \"BHN\", \"BHZ\"]), \n",
+    "                               timerange, storage_options=S3_STORAGE_OPTIONS)\n",
+    "ncedc_store = NCEDCS3DataStore(NCEDC_DATA, ncedc_catalog, channel_filter([\"NC\"], ncedc_stations, [\"HHE\", \"HHN\", \"HHZ\"]), \n",
+    "                               timerange, storage_options=S3_STORAGE_OPTIONS)\n",
+    "\n",
+    "raw_store = CompositeRawStore({\"CI\": scedc_store, \n",
+    "                               \"NC\": ncedc_store}) # Composite store for reading data from both SCEDC and NCEDC\n",
+    "cc_store = ASDFCCStore(cc_data_path) # Store for writing CC data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "get the time range of the data in the data store inventory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "span = raw_store.get_timespans()\n",
+    "print(span)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get the channels available during a given time spane"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "channel_list=raw_store.get_channels(span[1])\n",
+    "print(channel_list)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5qsPGkNp9Msx"
+   },
+   "source": [
+    "## Perform the cross correlation\n",
+    "The data will be pulled from SCEDC, cross correlated, and stored locally if this notebook is ran locally.\n",
+    "If you are re-calculating, we recommend to clear the old ``cc_store``."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "49MnDXYp9Msx"
+   },
+   "outputs": [],
+   "source": [
+    "cross_correlate(raw_store, config, cc_store)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "GMeH9BslQSSJ"
+   },
+   "source": [
+    "The cross correlations are saved as a single file for each channel pair and each increment of inc_hours. We now will stack all the cross correlations over all time chunk and look at all station pairs results.\n",
+    "\n",
+    "## Step 2: Stack the cross correlation\n",
+    "\n",
+    "We  now create the stack stores. Because this tutorial runs locally, we will use an ASDF stack store to output the data. ASDF is a data container in HDF5 that is used in full waveform modeling and inversion. H5 behaves well locally. \n",
+    "\n",
+    "Each station pair will have 1 H5 file with all components of the cross correlations. While this produces **many** H5 files, it has come down to the noisepy team's favorite option: \n",
+    "1. the thread-safe installation of HDF5 is not trivial\n",
+    "2. the choice of grouping station pairs within a single file is not flexible to a broad audience of users."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "cd32ntmAVx-z"
+   },
+   "outputs": [],
+   "source": [
+    "# open a new cc store in read-only mode since we will be doing parallel access for stacking\n",
+    "cc_store = ASDFCCStore(cc_data_path, mode=\"r\")\n",
+    "stack_store = ASDFStackStore(stack_data_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure the stacking\n",
+    "\n",
+    "There are various methods for optimal stacking. We refern to Yang et al (2022) for a discussion and comparison of the methods:\n",
+    "\n",
+    "Yang X, Bryan J, Okubo K, Jiang C, Clements T, Denolle MA. Optimal stacking of noise cross-correlation functions. Geophysical Journal International. 2023 Mar;232(3):1600-18. https://doi.org/10.1093/gji/ggac410\n",
+    "\n",
+    "Users have the choice to implement *linear*, phase weighted stacks *pws* (Schimmel et al, 1997), *robust* stacking (Yang et al, 2022), *acf* autocovariance filter (Nakata et al, 2019), *nroot* stacking. Users may choose the stacking method of their choice by entering the strings in ``config.stack_method``.\n",
+    "\n",
+    "If chosen *all*, the current code only ouputs *linear*, *pws*, *robust* since *nroot* is less common and *acf* is computationally expensive.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config.stack_method = StackMethod.LINEAR"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "method_list = [method for method in dir(StackMethod) if not method.startswith(\"__\")]\n",
+    "print(method_list)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cc_store.get_station_pairs()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stack_cross_correlations(cc_store, stack_store, config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "jQ-ey7uX9Msx"
+   },
+   "source": [
+    "## QC_1 of the cross correlations for Imaging\n",
+    "We now explore the quality of the cross correlations. We plot the moveout of the cross correlations, filtered in some frequency band."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cc_store.get_station_pairs()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pairs = stack_store.get_station_pairs()\n",
+    "print(f\"Found {len(pairs)} station pairs\")\n",
+    "sta_stacks = stack_store.read_bulk(None, pairs) # no timestamp used in ASDFStackStore"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "QKSeQpk7WKlW"
+   },
+   "outputs": [],
+   "source": [
+    "plot_all_moveout(sta_stacks, 'Allstack_linear', 0.1, 0.2, 'ZZ', 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "@webio": {
+   "lastCommId": null,
+   "lastKernelId": null
+  },
+  "colab": {
+   "provenance": []
+  },
+  "gpuClass": "standard",
+  "kernelspec": {
+   "display_name": ".env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/tutorials/noisepy_datastore.ipynb
+++ b/tutorials/noisepy_datastore.ipynb
@@ -45,7 +45,7 @@
    "outputs": [],
    "source": [
     "from noisepy.seis import  __version__       # noisepy core functions\n",
-    "from noisepy.seis.io.scedc_s3store import SCEDCS3DataStore # Object to query SCEDC data from on S3\n",
+    "from noisepy.seis.s3store import SCEDCS3DataStore # Object to query SCEDC data from on S3\n",
     "from noisepy.seis.io.channel_filter_store import channel_filter\n",
     "from noisepy.seis.io.channelcatalog import XMLStationChannelCatalog        # Required stationXML handling object\n",
     "from datetime import datetime\n",
@@ -84,7 +84,7 @@
    "source": [
     "A noisepy DataStore is a set of classes to accommodate the various types of data store that are necessary because how reseachers store their data, which can be dramatically different w.r.t. formats (mSEED, SAC, SEG-Y), file system (local, S3), and naming conventions. Our noisepy team does not impose a definite data structure, but instead suggest to wrap the data storage structure into a python class. A Data Store class can be the front-end of the real back-end data storage, and return data through read_data function. It allows users to customize based on how they store the data, and leaving the rest of the workflow untouched.\n",
     "\n",
-    "See https://github.com/noisepy/NoisePy/blob/main/src/noisepy/seis/stores.py for more about `DataStore` Class.\n",
+    "See https://github.com/noisepy/noisepy-io/blob/main/src/noisepy/seis/stores.py for more about `DataStore` Class.\n",
     "\n",
     "### S3 DataStore\n",
     "Here, we instantiate a `SCEDCS3DataStore` class as `raw_store` as an example of Data Store on the cloud. This variable allows reading data from the real data storage backend during the later processing. The initialization parameters of `SCEDCS3DataStore` are\n",
@@ -94,7 +94,7 @@
     "- time_range: DateTimeRange of data for processing.\n",
     "- storage_option: optimal storage option to read S3 data. This is where you can put AWS keys/credential if applicable.\n",
     "\n",
-    "See https://github.com/noisepy/NoisePy/blob/main/src/noisepy/seis/scedc_s3store.py for `SCEDCS3DataStore`\n",
+    "See https://github.com/noisepy/noisepy-io/blob/main/src/noisepy/seis/io/s3store.py for `SCEDCS3DataStore`\n",
     "\n",
     "We will work with a single day worth of data on SCEDC. The continuous data is organized with a single day and channel per miniseed (https://scedc.caltech.edu/data/cloud.html). For this example, you can choose any year since 2002. We will just cross correlate a single day."
    ]

--- a/tutorials/noisepy_datastore.ipynb
+++ b/tutorials/noisepy_datastore.ipynb
@@ -45,7 +45,7 @@
    "outputs": [],
    "source": [
     "from noisepy.seis import  __version__       # noisepy core functions\n",
-    "from noisepy.seis.s3store import SCEDCS3DataStore # Object to query SCEDC data from on S3\n",
+    "from noisepy.seis.io.s3store import SCEDCS3DataStore # Object to query SCEDC data from on S3\n",
     "from noisepy.seis.io.channel_filter_store import channel_filter\n",
     "from noisepy.seis.io.channelcatalog import XMLStationChannelCatalog        # Required stationXML handling object\n",
     "from datetime import datetime\n",

--- a/tutorials/noisepy_ncedc_tutorial.ipynb
+++ b/tutorials/noisepy_ncedc_tutorial.ipynb
@@ -67,7 +67,7 @@
     "%autoreload 2\n",
     "from noisepy.seis import cross_correlate, stack_cross_correlations, __version__       # noisepy core functions\n",
     "from noisepy.seis.io.asdfstore import ASDFCCStore, ASDFStackStore          # Object to store ASDF data within noisepy\n",
-    "from noisepy.seis.io.scedc_s3store import NCEDCS3DataStore # Object to query SCEDC data from on S3\n",
+    "from noisepy.seis.io.s3store import NCEDCS3DataStore # Object to query SCEDC data from on S3\n",
     "from noisepy.seis.io.channel_filter_store import channel_filter\n",
     "from noisepy.seis.io.datatypes import CCMethod, ConfigParameters, FreqNorm, RmResp, StackMethod, TimeNorm        # Main configuration object\n",
     "from noisepy.seis.io.channelcatalog import XMLStationChannelCatalog        # Required stationXML handling object\n",

--- a/tutorials/noisepy_scedc_tutorial.ipynb
+++ b/tutorials/noisepy_scedc_tutorial.ipynb
@@ -325,7 +325,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "channel_list=raw_store.get_channels(span[1])\n",
+    "channel_list=raw_store.get_channels(span[0])\n",
     "print(channel_list)"
    ]
   },

--- a/tutorials/noisepy_scedc_tutorial.ipynb
+++ b/tutorials/noisepy_scedc_tutorial.ipynb
@@ -110,7 +110,7 @@
     "S3_DATA = \"s3://scedc-pds/continuous_waveforms/\"\n",
     "# timeframe for analysis\n",
     "start = datetime(2002, 1, 1, tzinfo=timezone.utc)\n",
-    "end = datetime(2002, 1, 3, tzinfo=timezone.utc)\n",
+    "end = datetime(2002, 1, 2, tzinfo=timezone.utc)\n",
     "timerange = DateTimeRange(start, end)\n",
     "print(timerange)"
    ]

--- a/tutorials/noisepy_scedc_tutorial.ipynb
+++ b/tutorials/noisepy_scedc_tutorial.ipynb
@@ -67,7 +67,7 @@
     "%autoreload 2\n",
     "from noisepy.seis import cross_correlate, stack_cross_correlations, __version__       # noisepy core functions\n",
     "from noisepy.seis.io.asdfstore import ASDFCCStore, ASDFStackStore          # Object to store ASDF data within noisepy\n",
-    "from noisepy.seis.io.scedc_s3store import SCEDCS3DataStore # Object to query SCEDC data from on S3\n",
+    "from noisepy.seis.io.s3store import SCEDCS3DataStore # Object to query SCEDC data from on S3\n",
     "from noisepy.seis.io.channel_filter_store import channel_filter\n",
     "from noisepy.seis.io.datatypes import CCMethod, ConfigParameters, FreqNorm, RmResp, StackMethod, TimeNorm        # Main configuration object\n",
     "from noisepy.seis.io.channelcatalog import XMLStationChannelCatalog        # Required stationXML handling object\n",

--- a/tutorials/run_mpi_scedc.ipynb
+++ b/tutorials/run_mpi_scedc.ipynb
@@ -9,7 +9,7 @@
     "from noisepy.seis import cross_correlate, stack       # noisepy core functions\n",
     "from noisepy.seis.io import plotting_modules\n",
     "from noisepy.seis.io.asdfstore import ASDFCCStore                          # Object to store ASDF data within noisepy\n",
-    "from noisepy.seis.io.scedc_s3store import SCEDCS3DataStore # Object to query SCEDC data from on S3\n",
+    "from noisepy.seis.io.s3store import SCEDCS3DataStore # Object to query SCEDC data from on S3\n",
     "from noisepy.seis.io.channel_filter_store import channel_filter\n",
     "from noisepy.seis.io.datatypes import ConfigParameters, FreqNorm           # Main configuration object\n",
     "from noisepy.seis.io.channelcatalog import XMLStationChannelCatalog        # Required stationXML handling object\n",


### PR DESCRIPTION
We will use the updated io package, where the rename of `scedc_s3store` is simplified to `s3store`.