### PR TITLE
fix: update scipy dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "pydantic-yaml==1.0",
     "psutil>=5.9.5,<6.0.0",
     "noisepy-seis-io>=0.1.13",
+    "scipy==1.12.0"
 ]
 
 


### PR DESCRIPTION
The scipy made a new release April 2 2024 and moved the hanning function. This raised issues to our package. Thus, we need to restrict scipy to 1.12.0.